### PR TITLE
[fix] Android wechat browser playsinline handle

### DIFF
--- a/lib/index.browser.js
+++ b/lib/index.browser.js
@@ -7653,6 +7653,7 @@ var accessorMap = {
       var val = value ? '' : undefined;
       this.dom.setAttr('video', 'playsinline', val);
       this.dom.setAttr('video', 'webkit-playsinline', val);
+      this.dom.setAttr('video', 'x5-playsinline', val);
       this.dom.setAttr('video', 'x5-video-player-type', value ? 'h5' : undefined);
       return value;
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1007,6 +1007,7 @@ var accessorMap = {
       var val = value ? '' : undefined;
       this.dom.setAttr('video', 'playsinline', val);
       this.dom.setAttr('video', 'webkit-playsinline', val);
+      this.dom.setAttr('video', 'x5-playsinline', val);
       this.dom.setAttr('video', 'x5-video-player-type', value ? 'h5' : undefined);
       return value;
     }


### PR DESCRIPTION
在安卓微信里给`video`加上`x5-playsinline`属性可以让视频达到内嵌播放的效果。